### PR TITLE
Using json.From/FromAs with ChunkStream fails

### DIFF
--- a/extras/json/stream_chunk.go
+++ b/extras/json/stream_chunk.go
@@ -9,6 +9,6 @@ type StreamChunk struct {
 }
 
 // String makes this struct a fmt.Stringer
-func (s *StreamChunk) String() string {
+func (s StreamChunk) String() string {
 	return string(s.Bytes)
 }


### PR DESCRIPTION
Change fmt.Stringer String() function of StreamChunk to take a reference instead of a pointer as the From/FromAs functions expect a message reference and fail on casting to a fmt.Stringer